### PR TITLE
Update extra.css

### DIFF
--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,1 +1,1 @@
-@import url("https://nmfs-fish-tools.github.io/nmfspalette/extra.css");
+@import url("https://nmfs-ost.github.io/nmfspalette/extra.css");


### PR DESCRIPTION
I noticed the pkgdown styling isn't being found, and that's because the URL to the css file has changed!

Changing the location [like I did in ghactions4r just now](https://github.com/nmfs-fish-tools/ghactions4r/commit/88bfd05790ec594d6a62c3074095b86dc8c205e4) seemed to fix the issue.