### PR TITLE
Fix(93): remove code that checks for a libraried package 

### DIFF
--- a/R/verify_version.R
+++ b/R/verify_version.R
@@ -1,5 +1,11 @@
+#' Check version compatibility
+#'
+#'
+#' @param model output from \code{\link{fit_wham}}
+#'
+#' @noRd
+
 verify_version <- function(model){
-  if(!"wham" %in% .packages()) stop("wham library is not loaded")
   wham_commit <- packageDescription("wham")$GithubSHA1
   wham_commit <- ifelse(is.null(wham_commit), "local install", paste0("Github (timjmiller/wham@", wham_commit, ")")) 
   TMB_commit <- packageDescription("TMB")$GithubSHA1


### PR DESCRIPTION
### Justification

There is a line of code that checks to see if the `wham` package is in the users environment. This doesn't seem to serve a purpose and causes an error if the package is not in the environment. See related issue for more details

Fixes #93 

### Types of changes

What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [x] Fix (non-breaking change which fixes a bug)
- [ ] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)

### Reviewer instructions

To test: run the example code outlined in the reprex in issue (#93 ). Run this on both the `devel` branch and then on this branch
